### PR TITLE
Fix user highlights not updated on theme toggling

### DIFF
--- a/lua/base46/chadlights.lua
+++ b/lua/base46/chadlights.lua
@@ -19,7 +19,9 @@ if polish_hl then
 end
 
 -- override user highlights if there are any
-local user_highlights = ui.hl_override
+local user_hl_override = vim.deepcopy(ui.hl_override)
+local user_hl_add = vim.deepcopy(ui.hl_add)
+local user_highlights = merge_tb(user_hl_override, user_hl_add)
 local colors = require("base46").get_theme_tb "base_30"
 
 -- fg = "white" set by user becomes fg = colors["white"]

--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -56,7 +56,8 @@ M.load_all_highlights = function()
   end
 end
 
-M.turn_str_to_color = function(tb)
+M.turn_str_to_color = function(tb_in)
+  local tb = vim.deepcopy(tb_in)
   local colors = M.get_theme_tb "base_30"
 
   for _, groups in pairs(tb) do


### PR DESCRIPTION
Lua copies tables by reference, which leads to permanent replacements of
named colors to their absolute values in user highlight table.
Thus, when theme is toggled or changed, user highlights are not updated,
cause they are stuck with absolute values.
This commit does two thigs:
 * Copy user highlight tables by value
 * Add missing hl_add update in chadlights.lua