### PR TITLE
add copilot item kind to cmp config

### DIFF
--- a/lua/base46/integrations/cmp.lua
+++ b/lua/base46/integrations/cmp.lua
@@ -38,4 +38,5 @@ return {
   -- CmpItemKindEvent = { fg = "" },
   CmpItemKindOperator = { fg = base16.base05 },
   CmpItemKindTypeParameter = { fg = base16.base08 },
+  CmpItemKindCopilot = { fg = colors.green },
 }


### PR DESCRIPTION
i think this wasn't exactly what @siduck mentioned on discord, but I thought it would be better to keep cmp config in the same file, even copilot not being a default plugin

ps: I used the green color since the color used on @zbirenbaum doc was a heavy green 😁

btw, [this pr from UI repo](https://github.com/NvChad/ui/pull/25) adds the copilot icon