### PR TITLE
feat(compiler): reduce bytecode size

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -100,7 +100,7 @@ M.table_to_str = function(tb)
 end
 
 M.saveStr_to_cache = function(filename, tb)
-  -- Thanks to https://github.com/catppuccin/nvim and https://github.com/EdenEast/nightfox.nvim
+  -- Thanks to https://github.com/nullchilly and https://github.com/EdenEast/nightfox.nvim
   -- It helped me understand string.dump stuff
 
   local bg_opt = "vim.opt.bg='" .. M.get_theme_tb "type" .. "'"

--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -100,20 +100,18 @@ M.table_to_str = function(tb)
 end
 
 M.saveStr_to_cache = function(filename, tb)
-  -- Thanks to https://github.com/EdenEast/nightfox.nvim
+  -- Thanks to https://github.com/catppuccin/nvim and https://github.com/EdenEast/nightfox.nvim
   -- It helped me understand string.dump stuff
 
   local bg_opt = "vim.opt.bg='" .. M.get_theme_tb "type" .. "'"
   local defaults_cond = filename == "defaults" and bg_opt or ""
 
   local cache_path = vim.fn.stdpath "cache" .. "/nvchad/base46/"
-  local lines = 'require("base46").compiled = string.dump(function()' .. defaults_cond .. M.table_to_str(tb) .. "end)"
+  local lines = "return string.dump(function()" .. defaults_cond .. M.table_to_str(tb) .. "end, true)"
   local file = io.open(cache_path .. filename, "wb")
 
-  loadstring(lines, "=")()
-
   if file then
-    file:write(require("base46").compiled)
+    file:write(loadstring(lines)())
     file:close()
   end
 end
@@ -182,7 +180,7 @@ M.toggle_theme = function()
     g.toggle_theme_icon = "   "
     require("nvchad").replace_word('theme = "' .. theme2, 'theme = "' .. theme1)
   end
-  
+
   M.load_all_highlights()
 end
 


### PR DESCRIPTION
- Removes the requirement to save the compiled file to `require('base46').compiled` and read back again.
- We compiled to bytecode using `string.dump(f)` and then load with `loadstring(str, "=")` to strip the debug infos. A better way (to save binary size) would be `string.dump(f, true)` which strip the debug info and then load with `loadstring(str)`
- Also the `string.dump` idea is mine, so added credit