### PR TITLE
Add red color to Operators

### DIFF
--- a/lua/base46/themes/monekai.lua
+++ b/lua/base46/themes/monekai.lua
@@ -61,6 +61,7 @@ M.polish_hl = {
   ["@string"] = { fg = M.base_30.sun },
   ["@boolean"] = { fg = M.base_16.base09 },
   ["@punctuation.bracket"] = { fg = M.base_30.sun },
+  Operator = { fg = M.base_30.red },
   ["@operator"] = { fg = M.base_30.red },
 }
 


### PR DESCRIPTION
not and or operators in python are not colored. This change colors them in red.