### PR TITLE
added highlighting for diff files

### DIFF
--- a/lua/base46/integrations/diff.lua
+++ b/lua/base46/integrations/diff.lua
@@ -1,0 +1,25 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+
+  diffOldFile = {
+    fg = colors.baby_pink,
+  },
+
+  diffNewFile = {
+    fg = colors.blue,
+  },
+
+  diffChanged = {
+    fg = colors.orange,
+  },
+
+  diffRemoved = {
+    fg = colors.red,
+  },
+
+  diffAdded = {
+   fg = colors.green,
+  },
+
+}


### PR DESCRIPTION
This integration file adds support for missing highlightings when editing a .diff file

(cherry picked from commit a8524c2015f63a14992e6f67167a8823a6d23d04)
Signed-off-by: Thanatermesis <thanatermesis@gmail.com>