### PR TITLE
feat: make tbline respect ui.transparency option

### DIFF
--- a/lua/base46/integrations/tbline.lua
+++ b/lua/base46/integrations/tbline.lua
@@ -1,7 +1,8 @@
 local colors = require("base46").get_theme_tb "base_30"
 
-return {
+local config = require("core.utils").load_config().ui
 
+local highlights = {
   TblineFill = {
     bg = colors.black2,
   },
@@ -75,3 +76,15 @@ return {
     fg = colors.black,
   },
 }
+
+local hlgroups_glassy = {
+  "TblineFill",
+}
+
+if config.transparency then
+  for _, value in ipairs(hlgroups_glassy) do
+    highlights[value].bg = "NONE"
+  end
+end
+
+return highlights


### PR DESCRIPTION
Same as 3ea2ba1688787fa6c08b1f45ff0977e1bad0e67c, but for the tab line.

before/after:

![image](https://github.com/NvChad/base46/assets/3299086/663518a2-df79-4889-a8e7-5bdfe548bf72)

![image](https://github.com/NvChad/base46/assets/3299086/cc2e6f5c-6a63-4c1b-8d3e-1396b20bac8c)


---

> **Note**
> To disable transparency just for the tabline and restore the previous behaviour:

```lua
---@type ChadrcConfig
local M = {}

M.ui = {
  hl_override = {
    TblineFill = { bg = "your_black2_color" },
  }
  -- Or use "changed_themes" to override TblineFill per theme with the "polish_hl" attribute.
  --   https://nvchad.com/docs/config/theming
  --   https://github.com/NvChad/base46/blob/bad87b03/lua/base46/themes/doomchad.lua#L58-L61
}

return M
```