### PR TITLE
Enable base_16 color names for custom highlighting in hl_override/hl_add

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -28,7 +28,7 @@ local change_hex_lightness = require("base46.colors").change_hex_lightness
 -- turns color var names in hl_override/hl_add to actual colors
 -- hl_add = { abc = { bg = "one_bg" }} -> bg = colors.one_bg
 M.turn_str_to_color = function(tb)
-  local colors = M.get_theme_tb "base_30"
+  local colors = M.merge_tb(M.get_theme_tb "base_16", M.get_theme_tb "base_30")
   local copy = vim.deepcopy(tb)
 
   for _, hlgroups in pairs(copy) do


### PR DESCRIPTION
This may be useful for those users, who want to add color names like "base07" or "base0F" to their custom highlights config.
So users actualy will be able to switch themes, while preserving their custom global syntax highlighting rules.