### PR TITLE
fix: `nvim-notify` warning when bg is transparent.

### DIFF
--- a/lua/base46/extended_integrations/notify.lua
+++ b/lua/base46/extended_integrations/notify.lua
@@ -16,4 +16,5 @@ return {
   NotifyTRACEBorder = { fg = colors.purple },
   NotifyTRACEIcon = { fg = colors.purple },
   NotifyTRACETitle = { fg = colors.purple },
+  NotifyBackground = { bg = colors.black },
 }


### PR DESCRIPTION
Before:

![bfix](https://github.com/NvChad/base46/assets/74944536/1d0564b7-6184-454b-a861-bdfb984c7340)

After:
![afix](https://github.com/NvChad/base46/assets/74944536/19658b32-84f1-4e3f-9479-ae0a321754d6)
