### PR TITLE
add extendend_integration for vim-illuminate

### DIFF
--- a/lua/base46/extended_integrations/illuminate.lua
+++ b/lua/base46/extended_integrations/illuminate.lua
@@ -1,0 +1,7 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+  IlluminatedWordText = { bold = true, reverse = true },
+  IlluminatedWordRead = { bold = true, reverse = true },
+  IlluminatedWordWrite = { bold = true, reverse = true },
+}


### PR DESCRIPTION
This adds extended integration support for [vim-illumnate](https://github.com/RRethy/vim-illuminate).