### PR TITLE
add integration for vim-illuminate

### DIFF
--- a/lua/base46/integrations/illuminate.lua
+++ b/lua/base46/integrations/illuminate.lua
@@ -1,0 +1,7 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+  IlluminatedWordText = { bold = true, reverse = true },
+  IlluminatedWordRead = { bold = true, reverse = true },
+  IlluminatedWordWrite = { bold = true, reverse = true },
+}


### PR DESCRIPTION
Following #258. Add integration for [vim-illumintate](https://github.com/RRethy/vim-illuminate).

**NOTE** : Sorry, I haven't tested it : this is on v3.0, it seems is not yet stable version of NvChad, change of configuration has not already documented, and I am not able to predict impact on my current configuration.