### PR TITLE
feat: allow mixing highlight colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ M = require("base46").override_theme(M, "abc")
 return M
 ```
 
+### Color mixing
+
+It is possible to override or add highlight groups that mix two theme colors.
+When using the following "mix" style for setting highlight colors, using color
+names will result in the highlights adapting to match the current theme
+(even when switching themes).
+
+```lua
+hl_override = {
+  DiffAdd = {
+    -- Set the DiffAdd guibg color to a color 50% between
+    -- the "green" and "black" colors defined in the current theme
+    bg = {"green", "black", 50}
+  }
+}
+```
+
 ## Contribute
 
 - Send PR in the https://github.com/NvChad/base46/tree/v2.0/lua/base46/themes

--- a/lua/base46/colors.lua
+++ b/lua/base46/colors.lua
@@ -214,4 +214,44 @@ M.compute_gradient = function(hex1, hex2, steps)
   return gradient
 end
 
+-- Clamp a number between min and max.
+-- @param val The number to clamp.
+-- @param min The minimum (0 if not passed).
+-- @param max The maximum (1 if not passed).
+-- @return The clamped value between min and max.
+M.clamp = function(val, min, max)
+  if min == nil then min = 0 end
+  if max == nil then max = 1 end
+  return math.max(math.min(val, max), min)
+end
+
+-- Mix two colors with a given percentage.
+-- @param first The primary hex color.
+-- @param second The hex color you want to mix into the first color.
+-- @param strength The percentage of second color in the output.
+--                 This needs to be a number between 0 - 100.
+--                 Negative numbers will be clampled to 0.
+-- @return The mixed color as a hex value
+M.mix = function(first, second, strength)
+  if strength == nil then strength = 0.5 end
+
+  local s = M.clamp(strength/100)
+  local r1, g1, b1 = M.hex2rgb(first)
+  local r2, g2, b2 = M.hex2rgb(second)
+
+  if (r1 == nil or r2 == nil) then return first end
+
+  if (s == 0) then
+    return first
+  elseif (s == 1) then
+    return second
+  end
+
+  local r3 = r1 * (1 - s) + r2 * s
+  local g3 = g1 * (1 - s) + g2 * s
+  local b3 = b1 * (1 - s) + b2 * s
+
+  return M.rgb2hex(r3, g3, b3)
+end
+
 return M

--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -24,6 +24,7 @@ M.merge_tb = function(...)
 end
 
 local change_hex_lightness = require("base46.colors").change_hex_lightness
+local mix = require("base46.colors").mix
 
 -- turns color var names in hl_override/hl_add to actual colors
 -- hl_add = { abc = { bg = "one_bg" }} -> bg = colors.one_bg
@@ -35,13 +36,21 @@ M.turn_str_to_color = function(tb)
     for opt, val in pairs(hlgroups) do
       if opt == "fg" or opt == "bg" or opt == "sp" then
         if not (type(val) == "string" and val:sub(1, 1) == "#" or val == "none" or val == "NONE") then
-          hlgroups[opt] = type(val) == "table" and change_hex_lightness(colors[val[1]], val[2]) or colors[val]
+          if (type(val) == "table") then
+            if (#val == 2) then
+              hlgroups[opt] = change_hex_lightness(colors[val[1]], val[2])
+            else
+              hlgroups[opt] = mix(colors[val[1]], colors[val[2]], val[3])
+            end
+          else
+            hlgroups[opt] = colors[val]
+          end
         end
       end
     end
   end
 
-  return copy
+ return copy
 end
 
 M.extend_default_hl = function(highlights)


### PR DESCRIPTION
### What does this PR do?

This update allows users to define highlight colors that are a mix of two other colors in the theme. By specifying the mix colors as color names from the theme (ex "green" or "red"), the highlight groups will adapt to match the current theme as the user switches themes. This includes switching between light and dark themes.

```lua
hl_override = {
  DiffAdd = {
    -- Set the background of diff additions to a color
    -- 50% between the green and black values defined
    -- in the theme. For light themes, this will actually
    -- be a mix between green and white colors, resulting
    -- in a light green background. Dark themes will show
    -- a dark green background.
    bg = {"green", "black", 50}
  }
}
```

### How do I test it?

1) Set the following in your plugin spec
```lua
  {
    "NvChad/base46",
    branch = "feat/highlight-color-mix",
    url = "https://github.com/soulfresh/base46",
    build = function()
      require("base46").load_all_highlights()
    end,
  },
```

2) Add the following to your `hl_override` spec
```lua
  DiffAdd = {
    fg = "green",
    bg = {"green", "black", 90 },
  },
```

3) Restart nvim, open a diff and switch themes