### PR TITLE
Add customized gruvbox and nord theme

### DIFF
--- a/lua/base46/themes/gruvbox_origin.lua
+++ b/lua/base46/themes/gruvbox_origin.lua
@@ -1,0 +1,73 @@
+-- Credits to original https://github.com/morhetz/gruvbox
+-- This is modified version based on the origin gruvbox theme in base46
+-- better base16
+
+local M = {}
+
+M.base_30 = {
+  white = "#ebdbb2",
+  darker_black = "#232323",
+  black = "#282828", --  nvim bg
+  black2 = "#2e2e2e",
+  one_bg = "#353535",
+  one_bg2 = "#3f3f3f",
+  one_bg3 = "#444444",
+  grey = "#4b4b4b",
+  grey_fg = "#4e4e4e",
+  grey_fg2 = "#505050",
+  light_grey = "#656565",
+  red = "#fb4934",
+  baby_pink = "#cc241d",
+  pink = "#ff75a0",
+  line = "#36393a", -- for lines like vertsplit
+  green = "#b8bb26",
+  vibrant_green = "#a9b665",
+  nord_blue = "#83a598",
+  blue = "#458588",
+  yellow = "#d79921",
+  sun = "#fabd2f",
+  purple = "#b4bbc8",
+  dark_purple = "#d3869b",
+  teal = "#749689",
+  orange = "#e78a4e",
+  cyan = "#82b3a8",
+  statusline_bg = "#2c2c2c",
+  lightbg = "#3d3d3d",
+  -- pmenu_bg = "#83a598",
+  folder_bg = "#749689",
+}
+
+M.base_16 = {
+  base00 = "#282828",
+  base01 = "#3c3836",
+  base02 = "#423e3c",
+  base03 = "#484442",
+  base04 = "#bdae93",
+  base05 = "#d5c4a1",
+  base06 = "#ebdbb2",
+  base07 = "#fbf1c7",
+  base08 = "#83a598",
+  base09 = "#d3869b",
+  base0A = "#fabd2f",
+  base0B = "#b8bb26",
+  base0C = "#8ec07c",
+  base0D = "#b8bb26",
+  base0E = "#fb4943",
+  base0F = "#d65d0e",
+}
+
+M.type = "dark"
+
+M = require("base46").override_theme(M, "gruvbox")
+
+M.polish_hl = {
+  Operator = {
+    fg = M.base_30.nord_blue,
+  },
+
+  ["@operator"] = {
+    fg = M.base_30.nord_blue,
+  },
+}
+
+return M

--- a/lua/base46/themes/nord_origin.lua
+++ b/lua/base46/themes/nord_origin.lua
@@ -1,0 +1,67 @@
+-- Credits to original https://github.com/arcticicestudio/nord-vim
+-- This is modified version of it
+-- better base16 colors
+
+local M = {}
+
+M.base_30 = {
+  white = "#abb2bf",
+  darker_black = "#2a303c",
+  black = "#2E3440", --  nvim bg
+  black2 = "#343a46",
+  one_bg = "#373d49",
+  one_bg2 = "#464c58",
+  one_bg3 = "#494f5b",
+  grey = "#4b515d",
+  grey_fg = "#565c68",
+  grey_fg2 = "#606672",
+  light_grey = "#646a76",
+  red = "#BF616A",
+  baby_pink = "#de878f",
+  pink = "#d57780",
+  line = "#414753", -- for lines like vertsplit
+  green = "#A3BE8C",
+  vibrant_green = "#afca98",
+  blue = "#7797b7",
+  nord_blue = "#81A1C1",
+  yellow = "#EBCB8B",
+  sun = "#e1c181",
+  purple = "#B48EAD",
+  dark_purple = "#a983a2",
+  teal = "#6484a4",
+  orange = "#e39a83",
+  cyan = "#9aafe6",
+  statusline_bg = "#333945",
+  lightbg = "#3f4551",
+  pmenu_bg = "#A3BE8C",
+  folder_bg = "#7797b7",
+}
+
+M.base_16 = {
+  base00 = "#2E3440",
+  base01 = "#3B4252",
+  base02 = "#434C5E",
+  base03 = "#4C566A",
+  base04 = "#D8DEE9",
+  base05 = "#E5E9F0",
+  base06 = "#ECEFF4",
+  base07 = "#8FBCBB",
+  base08 = "#D8DEE9",
+  base09 = "#B48EAD",
+  base0A = "#81A1C1",
+  base0B = "#A3BE8C",
+  base0C = "#EBCB8B",
+  base0D = "#88C0D0",
+  base0E = "#81A1C1",
+  base0F = "#B48EAD",
+}
+
+M.polish_hl = {
+  ["@punctuation.bracket"] = { fg = M.base_16.base07 },
+  ["@punctuation.delimiter"] = { fg = M.base_30.white },
+}
+M.type = "dark"
+
+M = require("base46").override_theme(M, "nord")
+
+return M


### PR DESCRIPTION
Hi developers,

I like NvChad and like to change themes when coding :) I find the base16 color for  `gruvbox` and `nord` theme in default is a little wired, i.e., the `gruvbox` theme is too high contrast and the `nord` theme goes from light color to the deep color when u read the code ... 

So I changed the base16 palette for both themes to match their original look. Wish you could like it. Thanks!  

base46 gruvbox
![origin gruvbox](https://github.com/NvChad/base46/assets/45626759/27e88d1a-0009-4c1d-b75a-4ca031578346)
Modified gruvbox
![modified gruvbox](https://github.com/NvChad/base46/assets/45626759/f5e12e48-7810-478f-9190-8a81058f23fc)

base46 nord
![origin nord](https://github.com/NvChad/base46/assets/45626759/f1bc869d-7698-4891-9720-99f2f56818c0)
modified nord
![modified nord](https://github.com/NvChad/base46/assets/45626759/1acddf56-e29f-4cfa-84a2-d5fba8428a24)

Best,
Swanson