### PR TITLE
Fixed broken reference to chadrc.lua

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -158,7 +158,7 @@ M.toggle_theme = function()
 
   config.ui.theme = (themes[1] == config.ui.theme and themes[2]) or themes[1]
 
-  local old_theme = dofile(vim.fn.stdpath "config" .. "/lua/custom/chadrc.lua").ui.theme
+  local old_theme = dofile(vim.fn.stdpath "config" .. "/lua/chadrc.lua").ui.theme
   require("nvchad.utils").replace_word(old_theme, config.ui.theme)
   M.load_all_highlights()
 end
@@ -167,7 +167,7 @@ M.toggle_transparency = function()
   config.ui.transparency = not config.ui.transparency
   M.load_all_highlights()
 
-  local old_transparency_val = dofile(vim.fn.stdpath "config" .. "/lua/custom/chadrc.lua").ui.transparency
+  local old_transparency_val = dofile(vim.fn.stdpath "config" .. "/lua/chadrc.lua").ui.transparency
   local new_transparency_val = "transparency = " .. tostring(config.ui.transparency)
   require("nvchad.utils").replace_word("transparency = " .. tostring(old_transparency_val),new_transparency_val)
 end


### PR DESCRIPTION
Due to upgrading from v2.0 to v2.5, the `custom` directory was eliminated. This make the reference to `chadrc.lua` incorrect which causes an error when calling `toggle_transparency()`.

```
E5108: Error executing lua: cannot open /home/steven/.config/nvim/lua/custom/chadrc.lua: No such file or directory
stack traceback:
        [C]: in function 'dofile'
        ...steven/.local/share/nvim/lazy/base46/lua/base46/init.lua:170: in function 'toggle_transparency'
        /home/steven/.config/nvim/lua/mappings.lua:16: in function </home/steven/.config/nvim/lua/mappings.lua:15>
```

I've just removed `custom` from the path in two places.