### PR TITLE
fix: numbers highlighted with old color scheme upon theme switching

### DIFF
--- a/lua/base46/integrations/treesitter.lua
+++ b/lua/base46/integrations/treesitter.lua
@@ -21,6 +21,7 @@ return {
   ["@string.escape"] = { fg = theme.base0C },
   ["@character"] = { fg = theme.base08 },
   -- ["@character.special"] = { fg = theme.base08 },
+  ["@number"] = { fg = theme.base09 },
   ["@number.float"] = { fg = theme.base09 },
 
   ["@annotation"] = { fg = theme.base0F },


### PR DESCRIPTION
Added Number hlgroup on treesitter integration. 
This prevents display of number highlights defined by previous theme upon theme switching
![chardc_overiding_color](https://github.com/NvChad/base46/assets/88486564/01c23ff9-998f-4e31-a865-c32837e85f8c)
