### PR TITLE
DiagnosticInformation->DiagnosticInfo

### DIFF
--- a/lua/base46/integrations/lsp.lua
+++ b/lua/base46/integrations/lsp.lua
@@ -10,7 +10,7 @@ return {
   DiagnosticHint = { fg = colors.purple },
   DiagnosticError = { fg = colors.red },
   DiagnosticWarn = { fg = colors.yellow },
-  DiagnosticInformation = { fg = colors.green },
+  DiagnosticInfo = { fg = colors.green },
   LspSignatureActiveParameter = { fg = colors.black, bg = colors.green },
 
   RenamerTitle = { fg = colors.black, bg = colors.red },


### PR DESCRIPTION
Use proper name highlight - `DiagnosticInfo`, so base46 override works properly:
Before:
![image](https://github.com/NvChad/base46/assets/6512767/122929d8-16a9-4fe6-aad5-7e270dff94ae)
![image](https://github.com/NvChad/base46/assets/6512767/affaef3a-eef7-41db-985e-5cb76f08c2ab)

After:
![image](https://github.com/NvChad/base46/assets/6512767/dc260490-41f1-4362-a26d-7f277d69dad8)
![image](https://github.com/NvChad/base46/assets/6512767/eadbb94b-7a0f-4fc5-827a-5953bfc96b45)
