### PR TITLE
Update dap.lua

### DIFF
--- a/lua/base46/integrations/dap.lua
+++ b/lua/base46/integrations/dap.lua
@@ -4,6 +4,7 @@ return {
   -- Dap
   DapBreakpoint = { fg = colors.red },
   DapBreakpointCondition = { fg = colors.yellow },
+  DapBreakPointRejected = { fg = colors.orange },
   DapLogPoint = { fg = colors.cyan },
   DapStopped = { fg = colors.baby_pink },
 
@@ -45,4 +46,7 @@ return {
   DapUIRestartNC = { fg = colors.green },
   DapUIUnavailable = { fg = colors.grey_fg },
   DapUIUnavailableNC = { fg = colors.grey_fg },
+  
+  WinBar = { bg = colors.black1 },
+  WinBarNC = { bg = colors.black1 },
 }

--- a/lua/base46/integrations/dap.lua
+++ b/lua/base46/integrations/dap.lua
@@ -46,7 +46,4 @@ return {
   DapUIRestartNC = { fg = colors.green },
   DapUIUnavailable = { fg = colors.grey_fg },
   DapUIUnavailableNC = { fg = colors.grey_fg },
-  
-  WinBar = { bg = colors.black1 },
-  WinBarNC = { bg = colors.black1 },
 }


### PR DESCRIPTION
Made the highlighting better

Note that, due to the fact that all breakpoint signs uses the "SignColumn" highlight group, the following is needed in config to have the breakpoint highlighting functional.

```
            vim.fn.sign_define('DapBreakpoint', {text='B', texthl='DapBreakpoint', linehl='', numhl=''})
            vim.fn.sign_define('DapBreakpointCondition', {text='C', texthl='DapBreakpointCondition', linehl='', numhl=''})
            vim.fn.sign_define('DapBreakpointRejected', {text='R', texthl='DapBreakpointRejected', linehl='', numhl=''})
            vim.fn.sign_define('DapLogPoint', {text='L', texthl='DapLogPoint', linehl='', numhl=''})
            vim.fn.sign_define('DapStopped', {text='→', texthl='DapStopped', linehl='', numhl=''})
```