### PR TITLE
feat(ci): add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/ci-types-gen.yml
+++ b/.github/workflows/ci-types-gen.yml
@@ -39,7 +39,15 @@ jobs:
     - name: Update types
       run: |
         cd ~/.local/share/nvim/site/pack/ui/start/ui
-        nvim --headless "+luafile scripts/update-nvchad-types.lua" +qa
+        output=$(nvim --headless -c '+luafile scripts/update-nvchad-types.lua' +qa 2>&1)
+        status=$?
+        if [ $status -ne 0 ] || echo "$output" | grep -q "Error"; then
+          echo "Neovim failed with status $status"
+          echo "Error output:"
+          echo "$output"
+          exit 1
+        fi
+
 
     - name: Setup git credentials
       run: |

--- a/.github/workflows/ci-types-gen.yml
+++ b/.github/workflows/ci-types-gen.yml
@@ -4,6 +4,14 @@ on:
   push:
     branches:
       - v2.5
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
 
 jobs:
   update-nvchad-types:


### PR DESCRIPTION
Added workflow_dispatch as requested.
Also fixed the issue where some checks were incorrectly passing despite Neovim failing to execute the script. The problem was due to Neovim not returning the correct error code by default. To minimize changes in NvChad/ui, I opted to include a manual error check directly in the workflow.