### PR TITLE
keep winbar transparent

### DIFF
--- a/lua/base46/glassy.lua
+++ b/lua/base46/glassy.lua
@@ -29,6 +29,8 @@ local hl_groups = {
   "Pmenu",
   "CmpPmenu",
   "CmpDoc",
+  "WinBar",
+  "WinBarNC",
 }
 
 for _, groups in ipairs(hl_groups) do


### PR DESCRIPTION
Just adds WinBar and WinBarNC to the transparency table (bg="NONE") in glassy.lua