### PR TITLE
Add option to use more subtle highlight for LspReference{Read/Write/Text}

### DIFF
--- a/lua/base46/integrations/lsp.lua
+++ b/lua/base46/integrations/lsp.lua
@@ -1,26 +1,11 @@
 local colors = require("base46").get_theme_tb "base_30"
 local colorize = require("base46.colors").change_hex_lightness
 
-local nvconfig = require "nvconfig"
-local subtle_hover = nvconfig.ui.subtle_hover or nvconfig.base46.subtle_hover
-
-local lspReferenceText, lspReferenceRead, lspReferenceWrite
-
-if subtle_hover then
-  lspReferenceText = { bg = colors.grey }
-  lspReferenceRead = { bg = colors.grey }
-  lspReferenceWrite = { bg = colors.grey }
-else
-  lspReferenceText = { fg = colors.darker_black, bg = colors.white }
-  lspReferenceRead = { fg = colors.darker_black, bg = colors.white }
-  lspReferenceWrite = { fg = colors.darker_black, bg = colors.white }
-end
-
 return {
   -- LSP References
-  LspReferenceText = lspReferenceText,
-  LspReferenceRead = lspReferenceRead,
-  LspReferenceWrite = lspReferenceWrite,
+  LspReferenceText = { bg = colors.one_bg3 },
+  LspReferenceRead = { bg = colors.one_bg3 },
+  LspReferenceWrite = { bg = colors.one_bg3 },
 
   -- Lsp Diagnostics
   DiagnosticHint = { fg = colors.purple },

--- a/lua/base46/integrations/lsp.lua
+++ b/lua/base46/integrations/lsp.lua
@@ -1,11 +1,26 @@
 local colors = require("base46").get_theme_tb "base_30"
 local colorize = require("base46.colors").change_hex_lightness
 
+local nvconfig = require "nvconfig"
+local subtle_hover = nvconfig.ui.subtle_hover or nvconfig.base46.subtle_hover
+
+local lspReferenceText, lspReferenceRead, lspReferenceWrite
+
+if subtle_hover then
+  lspReferenceText = { bg = colors.grey }
+  lspReferenceRead = { bg = colors.grey }
+  lspReferenceWrite = { bg = colors.grey }
+else
+  lspReferenceText = { fg = colors.darker_black, bg = colors.white }
+  lspReferenceRead = { fg = colors.darker_black, bg = colors.white }
+  lspReferenceWrite = { fg = colors.darker_black, bg = colors.white }
+end
+
 return {
   -- LSP References
-  LspReferenceText = { fg = colors.darker_black, bg = colors.white },
-  LspReferenceRead = { fg = colors.darker_black, bg = colors.white },
-  LspReferenceWrite = { fg = colors.darker_black, bg = colors.white },
+  LspReferenceText = lspReferenceText,
+  LspReferenceRead = lspReferenceRead,
+  LspReferenceWrite = lspReferenceWrite,
 
   -- Lsp Diagnostics
   DiagnosticHint = { fg = colors.purple },


### PR DESCRIPTION
The way the LspReference{Read/Write/Text} highlights currently look are in my opinion to imposing and distracting:
![Currently with catppuccin](https://github.com/user-attachments/assets/bbf2b014-6fcd-4770-9895-9ec272b8b8a4)

Furthermore - at least for catppuccin - this is also not how the originial catppuccin theme looks.

When setting `ui.base64.subtle_hover = true` the used colors are changed:
```lua
local nvconfig = require "nvconfig"
local subtle_hover = nvconfig.ui.subtle_hover or nvconfig.base46.subtle_hover

local lspReferenceText, lspReferenceRead, lspReferenceWrite

if subtle_hover then
  lspReferenceText = { bg = colors.grey }
  lspReferenceRead = { bg = colors.grey }
  lspReferenceWrite = { bg = colors.grey }
else
  lspReferenceText = { fg = colors.darker_black, bg = colors.white }
  lspReferenceRead = { fg = colors.darker_black, bg = colors.white }
  lspReferenceWrite = { fg = colors.darker_black, bg = colors.white }
end

return {
  -- LSP References
  LspReferenceText = lspReferenceText,
  LspReferenceRead = lspReferenceRead,
  LspReferenceWrite = lspReferenceWrite,
  [...]
}
```

This results in the hovered/related elements looking like this:
![Hovering with "subtle_hover enabled"](https://github.com/user-attachments/assets/cc1af499-cad4-4923-9159-56f3235d5768)

I've also created a [draft pull request](https://github.com/NvChad/ui/pull/352) to add this option to `nvconfig.lua` file.

