### PR TITLE
hotfix(ci): match the current default branch for NvChad/ui

### DIFF
--- a/.github/workflows/ci-types-gen.yml
+++ b/.github/workflows/ci-types-gen.yml
@@ -63,7 +63,7 @@ jobs:
         git add -A
         if [[ -n "$(git status --porcelain)" ]]; then
           git commit -m "chore(types): update NvChad types"
-          git push origin v2.5
+          git push origin v3.0
         else
           echo "No changes to commit"
         fi


### PR DESCRIPTION
Currently investigating a potential implementation that wouldn't require us to hardcode the default branch (idea taken from lucario387)