### PR TITLE
Add diffview.nvim integration

### DIFF
--- a/lua/base46/integrations/diffview.lua
+++ b/lua/base46/integrations/diffview.lua
@@ -1,0 +1,13 @@
+local colors = require("base46").get_theme_tb "base_30"
+local mix_col = require("base46.colors").mix
+
+local highligths = {
+  DiffviewDiffAdd = { bg = mix_col(colors.green, colors.black, 85) },
+  DiffviewDiffText = { bg = mix_col(colors.green, colors.black, 70) },
+  DiffviewDiffChange = { bg = mix_col(colors.green, colors.black, 85) },
+  DiffviewDiffDelete = { bg = mix_col(colors.red, colors.black, 70) },
+  DiffviewDiffDeleteDim = { bg = mix_col(colors.red, colors.black, 85) },
+  DiffviewDiffAddAsDelete = { bg = mix_col(colors.red, colors.black, 85) },
+}
+
+return highligths


### PR DESCRIPTION
This integration fixes the colourscheme for diffview.nvim and matches it to that of GitHub code diff view.

Optimized for and tested with dark mode.

Recommended to use with the following options:
```lua
{
  enhanced_diff_hl = false,
  hooks = {
    diff_buf_read = function()
      vim.opt_local.wrap = false
    end,
    ---@diagnostic disable-next-line: unused-local
    diff_buf_win_enter = function(bufnr, winid, ctx)
      -- Highlight 'DiffChange' as 'DiffDelete' on the left, and 'DiffAdd' on
      -- the right.
      if ctx.layout_name:match "^diff2" then
        if ctx.symbol == "a" then
          vim.opt_local.winhl = table.concat({
            "DiffAdd:DiffviewDiffAddAsDelete",
            "DiffDelete:DiffviewDiffDelete",
            "DiffChange:DiffviewDiffAddAsDelete",
            "DiffText:DiffviewDiffDelete",
          }, ",")
        elseif ctx.symbol == "b" then
          vim.opt_local.winhl = table.concat({
            "DiffAdd:DiffviewDiffAdd",
            "DiffDelete:DiffviewDiffDelete",
            "DiffChange:DiffviewDiffAdd",
            "DiffText:DiffviewDiffText",
          }, ",")
        end
      end
      dofile(vim.g.base46_cache .. "git")
      dofile(vim.g.base46_cache .. "diffview")
    end,
  },
}
```
Sourced from [here](https://github.com/sindrets/dotfiles/blob/master/.config/nvim/lua/user/plugins/diffview.lua#L73-L98) and modified by me to match the integration highlights such that it does not interfere with the base theme highlights. Any suggestions would be much appreciated @siduck .