### PR TITLE
Add integration for yetone/avante.nvim

### DIFF
--- a/lua/base46/integrations/avante.lua
+++ b/lua/base46/integrations/avante.lua
@@ -1,0 +1,19 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+  AvanteTitle = {fg = colors.black2, bg = colors.vibrant_green},
+  AvanteReversedTitle = {fg = colors.vibrant_green, bg = colors.black2},
+  AvanteSubtitle = {fg = colors.black2, bg = colors.nord_blue},
+  AvanteReversedSubtitle = {fg = colors.nord_blue, bg = colors.black2},
+  AvanteThirdTitle = {bg = colors.white, fg=colors.black2},
+  AvanteReversedThirdTitle = {fg = colors.white},
+
+  -- should be set automatically by other color groups (i think)
+
+  -- AvanteConflictCurrent = {fg = '', bg = ''},
+  -- AvanteConflictCurrentLabel = {fg = '', bg = ''},
+  -- AvanteConflictIncoming = {fg = '', bg = ''},
+  -- AvanteConflictIncomingLabel = {fg = '', bg = ''},
+  -- AvantePopupHint = {fg = '', bg = ''},
+  -- AvanteInlineHint = {fg = '', bg = ''}
+}

--- a/lua/base46/integrations/avante.lua
+++ b/lua/base46/integrations/avante.lua
@@ -8,7 +8,7 @@ return {
   AvanteThirdTitle = {bg = colors.white, fg=colors.black2},
   AvanteReversedThirdTitle = {fg = colors.white},
 
-  -- should be set automatically by other color groups (i think)
+  -- should be set automatically by other color groups
 
   -- AvanteConflictCurrent = {fg = '', bg = ''},
   -- AvanteConflictCurrentLabel = {fg = '', bg = ''},


### PR DESCRIPTION
Adds support for [avante.nvim](//github.com/yetone/avante.nvim) highlight groups.

<img width="1178" alt="Screenshot 2024-11-09 at 5 45 18 PM" src="https://github.com/user-attachments/assets/a22c66ed-9d5a-4839-b16e-93db66127e33">
