### PR TITLE
feat: integration for nvim-orgmode/orgmode

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -13,6 +13,7 @@ local integrations = {
   "mason",
   "nvcheatsheet",
   "nvimtree",
+  "orgmode",
   "statusline",
   "syntax",
   "treesitter",

--- a/lua/base46/integrations/orgmode.lua
+++ b/lua/base46/integrations/orgmode.lua
@@ -1,0 +1,10 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+  ["@org.headline.level1.org"] = { fg = colors.red },
+  ["@org.headline.level2.org"] = { fg = colors.orange },
+  ["@org.headline.level3.org"] = { fg = colors.yellow },
+  ["@org.headline.level4.org"] = { fg = colors.green },
+  ["@org.headline.level5.org"] = { fg = colors.blue },
+  ["@org.headline.level6.org"] = { fg = colors.purple },
+}


### PR DESCRIPTION
Hi, I added a small integration for `nvim-orgmode/orgmode` based on the integration for `markview`. 

Here is how it looks:
* Before
![image](https://github.com/user-attachments/assets/f7654838-9f75-4e86-8e0a-f5a30d51184c)
* After
![image](https://github.com/user-attachments/assets/8af83bf1-9434-47c3-b3ba-aae92710aadd)
