### PR TITLE
feat: add akinsho/git-conflict.nvim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ and then read `:h nvui.base46`
 - Trouble.nvim 
 - Whichkey.nvim
 - git-conflict.nvim
+- Orgmode.nvim
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ and then read `:h nvui.base46`
 - Trouble.nvim 
 - Whichkey.nvim
 - git-conflict.nvim
-- Orgmode.nvim
+- Orgmode
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ and then read `:h nvui.base46`
 - Lsp Semantic tokens
 - Trouble.nvim 
 - Whichkey.nvim
+- git-conflict.nvim
 
 ## Configuration
 

--- a/lua/base46/integrations/git-conflict.lua
+++ b/lua/base46/integrations/git-conflict.lua
@@ -1,0 +1,11 @@
+local colors = require("base46").get_theme_tb "base_30"
+local mix_col = require("base46.colors").mix
+
+-- Need to manually re-configure git-conflict.nvim to use these highlight groups.
+-- See: https://github.com/akinsho/git-conflict.nvim?tab=readme-ov-file#configuration
+local highligths = {
+  GitConflictDiffAdd = { bg = mix_col(colors.blue, colors.black, 85) },
+  GitConflictDiffText = { bg = mix_col(colors.green, colors.black, 85) },
+}
+
+return highligths


### PR DESCRIPTION
I defined new highlight groups here so as not to override the default DiffAdd and DiffText highlight groups.

If there is a way to override these instead, but only for this plugin, I would be happy to update my PR to reflect this, as then it would not require any manual configuration of the plugin.

These highlight groups follow VSCode's way of highlighting conflicts (green and blue).

Thanks.