### PR TITLE
feat: add leap.nvim integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ and then read `:h nvui.base46`
 - git-conflict.nvim
 - Orgmode
 - diffview.nvim
+- leap.nvim
 
 ## Configuration
 

--- a/lua/base46/integrations/leap.lua
+++ b/lua/base46/integrations/leap.lua
@@ -1,0 +1,7 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+  LeapBackdrop = { fg = colors.grey_fg },
+  LeapLabel = { fg = colors.yellow, bold = true },
+  LeapMatch = { fg = colors.yellow, bold = true },
+}


### PR DESCRIPTION
Adds the integration for [leap.nvim](https://github.com/ggandor/leap.nvim) and updates the README