### PR TITLE
NvimTree diagnostic highlight and new integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,17 @@ and then read `:h nvui.base46`
 - Todo.nvim
 - Nvim-treesitter
 - Lsp Semantic tokens
-- Trouble.nvim 
+- Trouble.nvim
 - Whichkey.nvim
 - git-conflict.nvim
 - Orgmode
 - diffview.nvim
 - leap.nvim
+- Edgy.nvim
 
 ## Configuration
 
-- Base46 is configured by [nvconfig](https://github.com/NvChad/ui/blob/v2.5/lua/nvconfig.lua) in your path. 
+- Base46 is configured by [nvconfig](https://github.com/NvChad/ui/blob/v2.5/lua/nvconfig.lua) in your path.
 - Read the [themeing docs](https://nvchad.com/docs/config/theming)
 
 ## Highlight command
@@ -63,8 +64,8 @@ vim.api.nvim_set_hl(0, "Comment", {
 
 There are 2 main tables used for `base46`
 
-- `base_30` is used for general UI 
-- `base_16` is used for syntax highlighting 
+- `base_30` is used for general UI
+- `base_16` is used for syntax highlighting
 - Use a color lightening/darkening tool, such as this
   https://imagecolorpicker.com/color-code
 
@@ -135,8 +136,8 @@ M.base_16 = {
 }
 
 -- OPTIONAL
--- overriding or adding highlights for this specific theme only 
--- defaults/treesitter is the filename i.e integration there, 
+-- overriding or adding highlights for this specific theme only
+-- defaults/treesitter is the filename i.e integration there,
 
 M.polish_hl = {
   defaults = {

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ and then read `:h nvui.base46`
 - diffview.nvim
 - leap.nvim
 - Edgy.nvim
+- Grug-far.nvim
 
 ## Configuration
 

--- a/lua/base46/integrations/edgy.lua
+++ b/lua/base46/integrations/edgy.lua
@@ -1,0 +1,9 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+local highligths = {
+  EdgyNormal = { fg = colors.white },
+  EdgyWinBar = { fg = colors.white },
+  EdgyWinBarInactive = { fg = colors.white },
+}
+
+return highligths

--- a/lua/base46/integrations/grug_far.lua
+++ b/lua/base46/integrations/grug_far.lua
@@ -1,0 +1,7 @@
+local highligths = {
+  GrugFarResultsMatch = { link = "DiffChange" },
+  GrugFarResultsMatchAdded = { link = "DiffAdd" },
+  GrugFarResultsMatchRemoved = { link = "DiffDelete" },
+}
+
+return highligths

--- a/lua/base46/integrations/nvimtree.lua
+++ b/lua/base46/integrations/nvimtree.lua
@@ -16,6 +16,14 @@ return {
   NvimTreeNormalNC = { bg = colors.darker_black },
   NvimTreeOpenedFolderName = { fg = colors.folder_bg },
   NvimTreeGitIgnored = { fg = colors.light_grey },
+  NvimTreeDiagnosticErrorFileHL = { link = "DiagnosticError" },
+  NvimTreeDiagnosticErrorFolderHL = { link = "DiagnosticError" },
+  NvimTreeDiagnosticInfoFileHL =  { link = "DiagnosticNormal" },
+  NvimTreeDiagnosticInfoFolderHL =  { link = "DiagnosticNormal" },
+  NvimTreeDiagnosticWarnFileHL = { link = "DiagnosticWarn" },
+  NvimTreeDiagnosticWarnFolderHL = { link = "DiagnosticWarn" },
+  NvimTreeDiagnosticHintFileHL = { link = "DiagnosticHint" },
+  NvimTreeDiagnosticHintFolderHL = { link = "DiagnosticHint" },
 
   NvimTreeWinSeparator = {
     fg = colors.darker_black,


### PR DESCRIPTION
- Created highlights for [Edgy](https://github.com/folke/edgy.nvim).
- Created highlights for [Grug-far.nvim](https://github.com/MagicDuck/grug-far.nvim).
- Added highlights for NvimTree diagnostics integration, NvChad has this integration turned off by default, so if the user turns on the integration, the highlight will match our current theme.

NvimTree:
![image](https://github.com/user-attachments/assets/a4cbbdcf-3c45-4370-9a73-5b42cb9436ad)

Edgy and GrugFar:
![image](https://github.com/user-attachments/assets/589105c5-dc30-4ed5-a99b-85d62c48a390)

