### PR TITLE
Fix: Writing `transparency` to `chadrc`

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -207,7 +207,7 @@ M.toggle_transparency = function()
   M.load_all_highlights()
 
   package.loaded.chadrc = nil
-  local old = require("chadrc").transparency
+  local old = require("chadrc").base46.transparency
   local new = "transparency = " .. tostring(opts.transparency)
   require("nvchad.utils").replace_word("transparency = " .. tostring(old), new)
 end


### PR DESCRIPTION
Change `require("chadrc").transparency` to `require("chadrc").base46.transparency` to match the structure of `nvconfig`