### PR TITLE
Fix: Handle table values in highlight options properly #428

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -117,9 +117,24 @@ M.tb_2str = function(tb)
     local hlopts = ""
 
     for optName, optVal in pairs(v) do
-      local valueInStr = ((type(optVal)) == "boolean" or type(optVal) == "number") and tostring(optVal)
-        or '"' .. optVal .. '"'
-      hlopts = hlopts .. optName .. "=" .. valueInStr .. ","
+      local valtype = type(optVal)
+
+      if valtype == "boolean" or valtype == "number" or valtype == "string" then
+        local valueInStr = tostring(optVal)
+        if valtype == "string" then
+          valueInStr = '"' .. valueInStr .. '"'
+        end
+        hlopts = hlopts .. optName .. "=" .. valueInStr .. ","
+      elseif valtype == "table" then
+        -- For handling table values (e.g., "link") properly
+        local valueInStr = "{"
+        for k,v in pairs(optVal) do
+          local vstr = type(v) == "string" and '"' .. v .. '"' or tostring(v)
+          valueInStr = valueInStr .. tostring(k) .. "=" .. vstr .. ","
+        end
+        valueInStr = valueInStr .. "}"
+        hlopts = hlopts .. optName .. "=" .. valueInStr .. ","
+      end
     end
 
     result = result .. "vim.api.nvim_set_hl(0," .. hlname .. "{" .. hlopts .. "})"


### PR DESCRIPTION
This PR fixes the #428 [issue](https://github.com/NvChad/ui/issues/428)

The plugins actually doesn't work properly in anywhere neither windows, nor WSL. It works only for the first time after the plugin installs(not just with volt theme switcher but also in case of `Telescope themes`).

The problem was in the `init.lua` inside `lua/base46` directory of the `base46` plugin.

The old `tb_2str` function - 
```lua
M.tb_2str = function(tb)
  local result = ""

  for hlgroupName, v in pairs(tb) do
    local hlname = "'" .. hlgroupName .. "',"
    local hlopts = ""

    for optName, optVal in pairs(v) do
      local valueInStr = ((type(optVal)) == "boolean" or type(optVal) == "number") and tostring(optVal)
        or '"' .. optVal .. '"'
      hlopts = hlopts .. optName .. "=" .. valueInStr .. ","
    end

    result = result .. "vim.api.nvim_set_hl(0," .. hlname .. "{" .. hlopts .. "})"
  end

  return result
end
```
As far as I understand, this function converts a highlight group table into a string of `nvim_set_hl` commands.
The problem is that some highlight options (like link) can have table values, and the current code tries to concatenate them as strings.

This is the original code, which tried to concatenate a table directly, which is not allowed in Lua. 

So, I corrected the function definition to properly convert highlight table to string even if the tables has some table values as properties.
This is the new function definition - 
```lua
M.tb_2str = function(tb)
  local result = ""

  for hlgroupName, v in pairs(tb) do
    local hlname = "'" .. hlgroupName .. "',"
    local hlopts = ""

    for optName, optVal in pairs(v) do
      local valtype = type(optVal)

      if valtype == "boolean" or valtype == "number" or valtype == "string" then
        local valueInStr = tostring(optVal)
        if valtype == "string" then
          valueInStr = '"' .. valueInStr .. '"'
        end
        hlopts = hlopts .. optName .. "=" .. valueInStr .. ","
      elseif valtype == "table" then
        -- For handling table values (e.g., "link") properly
        local valueInStr = "{"
        for k,v in pairs(optVal) do
          local vstr = type(v) == "string" and '"' .. v .. '"' or tostring(v)
          valueInStr = valueInStr .. tostring(k) .. "=" .. vstr .. ","
        end
        valueInStr = valueInStr .. "}"
        hlopts = hlopts .. optName .. "=" .. valueInStr .. ","
      end
    end

    result = result .. "vim.api.nvim_set_hl(0," .. hlname .. "{" .. hlopts .. "})"
  end

  return result
end
```

The new `tb_2str` checks for the `table` type and iterates through the table's key-value pairs, formatting them into a string representation suitable for `nvim_set_hl`.
Thus the PR has resolved the "attempt to concatenate local 'optVal' (a table value)" error and restores the functionality of theme switching and other features relying on highlight linking. 

I have tested this code in both Windows 11 and WSL. Works like a charm.
Now base46 theme changing works with both Telescope and volt theme picker plugins.

Kindly review the changes whether this solution is viable for merging.
Thanks in advance,

https://github.com/user-attachments/assets/3dff5ffb-bc8f-43b2-aced-1ecb1e6d1169

