### PR TITLE
feat(integration): mini-tabline

### DIFF
--- a/lua/base46/integrations/mini-tabline.lua
+++ b/lua/base46/integrations/mini-tabline.lua
@@ -1,0 +1,57 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+local config = require "nvconfig"
+
+local highlights = {
+  MiniTablineCurrent = {
+    fg = colors.white,
+    bg = colors.black,
+  },
+
+  MiniTablineVisible = {
+    fg = colors.white,
+    bg = colors.black,
+  },
+
+  MiniTablineHidden = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+
+  MiniTablineModifiedCurrent = {
+    fg = colors.green,
+    bg = colors.black,
+  },
+
+  MiniTablineModifiedVisible = {
+    fg = colors.green,
+    bg = colors.black,
+  },
+
+  MiniTablineModifiedHidden = {
+    fg = colors.red,
+    bg = colors.black2,
+  },
+
+  MiniTablineTabpagesection = {
+    fg = colors.black,
+    bg = colors.blue,
+  },
+}
+
+local hlgroups_glassy = {
+  "MiniTablineCurrent",
+  "MiniTablineVisible",
+  "MiniTablineHidden",
+  "MiniTablineModifiedCurrent",
+  "MiniTablineModifiedVisible",
+  "MiniTablineModifiedHidden",
+}
+
+if config.base46.transparency then
+  for _, val in ipairs(hlgroups_glassy) do
+    highlights[val].bg = "NONE"
+  end
+end
+
+return highlights


### PR DESCRIPTION
Use `tbline.lua` as reference and follow the default behavior of `mini.tabline`:

1. `MiniTablineFill` remains unchanged and linked to `Normal` by default;
2. Current Buffer (where cursor exists) and Visible Buffer share the same highlight;
3. No default hl group for Modified Buffer so refer to `tbline.lua`.

![image](https://github.com/user-attachments/assets/034d8233-263c-4d33-a4ad-56706af752be)

![image](https://github.com/user-attachments/assets/1a3ca031-05ab-4f23-b010-dcab12a6b5db)
