### PR TITLE
Add mini-icons integration and modify bufferline integration to support mini-icons

### DIFF
--- a/lua/base46/integrations/bufferline.lua
+++ b/lua/base46/integrations/bufferline.lua
@@ -7,7 +7,7 @@ return {
     bg = colors.black2,
   },
 
-  BufferlineIndicatorVisible = {
+  BufferLineIndicatorVisible = {
     fg = colors.black2,
     bg = colors.black2,
   },
@@ -32,7 +32,89 @@ return {
     fg = colors.light_grey,
     bg = colors.black2,
   },
+  BufferLineErrorDiagnosticSelected = {
+    fg = colors.red,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.red,
+  },
+  BufferLineErrorSelected = {
+    fg = colors.red,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.red,
+  },
 
+  BufferLineInfo = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+  BufferLineInfoDiagnostic = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+  BufferLineInfoDiagnosticSelected = {
+    fg = colors.blue,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.red,
+  },
+  BufferLineInfoSelected = {
+    fg = colors.blue,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.red,
+  },
+
+  BufferLineWarning = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+  BufferLineWarningDiagnostic = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+  BufferLineWarningDiagnosticSelected = {
+    fg = colors.yellow,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.yellow,
+  },
+  BufferLineWarningSelected = {
+    fg = colors.yellow,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.yellow,
+  },
+
+  BufferLineHint = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+  BufferLineHintDiagnostic = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
+  BufferLineHintDiagnosticSelected = {
+    fg = colors.purple,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.purple,
+  },
+  BufferLineHintSelected = {
+    fg = colors.purple,
+    bg = colors.black,
+    bold = true,
+    italic = true,
+    sp = colors.purple,
+  },
   -- close buttons
   BufferLineCloseButton = {
     fg = colors.light_grey,
@@ -50,7 +132,7 @@ return {
     fg = colors.grey_fg,
     bg = colors.black2,
   },
-  BufferlineIndicatorSelected = {
+  BufferLineIndicatorSelected = {
     fg = colors.black,
     bg = colors.black,
   },
@@ -126,4 +208,24 @@ return {
   BufferLineRightCustomAreaText2 = {
     fg = colors.red,
   },
+
+  -- MiniIcons integration
+  BufferLineMiniIconsYellow = { fg = colors.yellow, bg = colors.black2 },
+  BufferLineMiniIconsYellowSelected = { fg = colors.yellow, bg = colors.black },
+  BufferLineMiniIconsOrange = { fg = colors.orange, bg = colors.black2 },
+  BufferLineMiniIconsOrangeSelected = { fg = colors.orange, bg = colors.black },
+  BufferLineMiniIconsAzure = { fg = colors.teal, bg = colors.black2 },
+  BufferLineMiniIconsAzureSelected = { fg = colors.teal, bg = colors.black },
+  BufferLineMiniIconsCyan = { fg = colors.cyan, bg = colors.black2 },
+  BufferLineMiniIconsCyanSelected = { fg = colors.cyan, bg = colors.black },
+  BufferLineMiniIconsPurple = { fg = colors.purple, bg = colors.black2 },
+  BufferLineMiniIconsPurpleSelected = { fg = colors.purple, bg = colors.black },
+  BufferLineMiniIconsBlue = { fg = colors.blue, bg = colors.black2 },
+  BufferLineMiniIconsBlueSelected = { fg = colors.blue, bg = colors.black },
+  BufferLineMiniIconsRed = { fg = colors.red, bg = colors.black2 },
+  BufferLineMiniIconsRedSelected = { fg = colors.red, bg = colors.black },
+  BufferLineMiniIconsGreen = { fg = colors.green, bg = colors.black2 },
+  BufferLineMiniIconsGreenSelected = { fg = colors.green, bg = colors.black },
+  BufferLineMiniIconsGrey = { fg = colors.white, bg = colors.black2 },
+  BufferLineMiniIconsGreySelected = { fg = colors.white, bg = colors.black },
 }

--- a/lua/base46/integrations/mini-icons.lua
+++ b/lua/base46/integrations/mini-icons.lua
@@ -1,0 +1,36 @@
+local colors = require("base46").get_theme_tb "base_30"
+
+return {
+  MiniIcons = {
+    -- seems to be normal text
+    -- cleared
+  },
+  MiniIconsAzure = {
+    fg = colors.teal,
+  },
+  MiniIconsBlue = {
+    fg = colors.blue,
+  },
+  MiniIconsRed = {
+    fg = colors.red,
+  },
+  MiniIconsYellow = {
+    fg = colors.yellow,
+  },
+  MiniIconsOrange = {
+    fg = colors.orange,
+  },
+  MiniIconsGreen = {
+    fg = colors.green,
+  },
+  MiniIconsPurple = {
+    fg = colors.purple,
+  },
+  MiniIconsCyan = {
+    fg = colors.cyan,
+  },
+
+  MiniIconsGrey = {
+    fg = colors.white,
+  },
+}


### PR DESCRIPTION
As discussed on Discord added support for mini-icons as well as bufferline support for mini-icons.

Also fixed a few typos in `bufferline.lua`.

It might be a good idea to extract part of the code to `bufferline-mini-icons.lua` instead of having it all in `bufferline.lua`. @siduck, feel free to comment on what you think and I'll modify the PR.