### PR TITLE
Small fix to make arrows on sides of bufferline blend in better

### DIFF
--- a/lua/base46/integrations/bufferline.lua
+++ b/lua/base46/integrations/bufferline.lua
@@ -1,6 +1,10 @@
 local colors = require("base46").get_theme_tb "base_30"
 
 return {
+  BufferLineTruncMarker = {
+    fg = colors.light_grey,
+    bg = colors.black2,
+  },
 
   BufferLineBackground = {
     fg = colors.light_grey,


### PR DESCRIPTION
Makes the arrows on the sides blend in better:
<img width="693" height="135" alt="image" src="https://github.com/user-attachments/assets/dbe120c3-8371-4eba-b87d-d843d7000328" />
