### PR TITLE
feat: update markview.nvim integration to use new highlight groups

### DIFF
--- a/lua/base46/integrations/markview.lua
+++ b/lua/base46/integrations/markview.lua
@@ -1,10 +1,10 @@
 local colors = require("base46").get_theme_tb "base_30"
-
+local mix = require("base46.colors").mix
 return {
-  ["@markup.heading.1.markdown"] = { fg = colors.red },
-  ["@markup.heading.2.markdown"] = { fg = colors.orange },
-  ["@markup.heading.3.markdown"] = { fg = colors.yellow },
-  ["@markup.heading.4.markdown"] = { fg = colors.green },
-  ["@markup.heading.5.markdown"] = { fg = colors.blue },
-  ["@markup.heading.6.markdown"] = { fg = colors.purple },
+  MarkviewPalette0 = { fg = colors.red, bg = mix(colors.blue, colors.black, 90) },
+  MarkviewPalette1 = { fg = colors.orange, bg = mix(colors.yellow, colors.black, 90) },
+  MarkviewPalette2 = { fg = colors.yellow, bg = mix(colors.green, colors.black, 90) },
+  MarkviewPalette3 = { fg = colors.green, bg = mix(colors.teal, colors.black, 90) },
+  MarkviewPalette4 = { fg = colors.blue, bg = mix(colors.purple, colors.black, 90) },
+  MarkviewPalette5 = { fg = colors.purple, bg = mix(colors.pink, colors.black, 90) },
 }


### PR DESCRIPTION
Updated the integration for markview.nvim plugin to use the new highlight groups 
instead of  `@markup.headings`.

## Changes
- Replaced `@markup.headings` with `MarkviewPalette[0-5]`
- Updated /lua/base64/integrations/markview.lua

- Enables proper theme switching functionality

![video](https://github.com/user-attachments/assets/723e5521-462f-4921-a2e8-011a6f2a2208)

