### PR TITLE
Fix confusing default color mix strength

### DIFF
--- a/lua/base46/colors.lua
+++ b/lua/base46/colors.lua
@@ -278,7 +278,7 @@ end
 -- @return The mixed color as a hex value
 M.mix = function(first, second, strength)
   if strength == nil then
-    strength = 0.5
+    strength = 50
   end
 
   local s = strength / 100


### PR DESCRIPTION
Changes the default value of the strength argument of the color mix function.  
It was previously (mistakenly?) set to 0.5% instead of 50%.  
  
Does not have any impact on existing themes.