### PR TITLE
Added support for custom integration file loading

### DIFF
--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -129,10 +129,10 @@ M.get_integration = function(name)
     highlights = require("base46.integrations." .. name)
   else
     local ok
-    ok, highlights = pcall(require, integrations_dir .. "." .. name)
+    ok, highlights = pcall(require, "base46.integrations." .. name)
 
     if not ok then
-      highlights = require("base46.integrations." .. name)
+      highlights = require(integrations_dir .. "." .. name)
     end
   end
 

--- a/lua/base46/init.lua
+++ b/lua/base46/init.lua
@@ -30,6 +30,8 @@ local integrations = {
   "whichkey",
 }
 
+local integrations_dir = opts.integrations_dir or nil
+
 for _, value in ipairs(opts.integrations) do
   table.insert(integrations, value)
 end
@@ -121,7 +123,19 @@ M.extend_default_hl = function(highlights, integration_name)
 end
 
 M.get_integration = function(name)
-  local highlights = require("base46.integrations." .. name)
+  local highlights
+
+  if not integrations_dir then
+    highlights = require("base46.integrations." .. name)
+  else
+    local ok
+    ok, highlights = pcall(require, integrations_dir .. "." .. name)
+
+    if not ok then
+      highlights = require("base46.integrations." .. name)
+    end
+  end
+
   return M.extend_default_hl(highlights, name)
 end
 


### PR DESCRIPTION
This is a small change ( non breaking ), that'll let us add integration files from our local dir.

Inside base46
```lua 
integrations = {
  "dap", 
  "custom",  -- looks inside our specified dir
   -- in this case its lua/int/custom.lua
  "anyelse", -- lua/int/anyelse.lua
}, 
integrations_dir = "int" 
```
Why this change? Because it's a lot easier to test it out and develop new integrations files for base46.