### PR TITLE
feat(integrations, statusline): make the statusline of the active win…

### DIFF
--- a/lua/base46/integrations/statusline/default.lua
+++ b/lua/base46/integrations/statusline/default.lua
@@ -3,11 +3,13 @@ local get_theme_tb = require("base46").get_theme_tb
 local colors = get_theme_tb "base_30"
 local generate_color = require("base46.colors").change_hex_lightness
 
-local statusline_bg = config.base46.transparency and "NONE" or colors.statusline_bg
+local statusline_bg = config.base46.transparency and "NONE" or colors.darker_black
+local statusline_nc_bg = config.base46.transparency and "NONE" or colors.statusline_bg
 local light_grey = generate_color(colors.light_grey, 8)
 
 local M = {
   StatusLine = { bg = statusline_bg },
+  StatusLineNC = { bg = statusline_nc_bg },
   St_gitIcons = { fg = light_grey, bg = statusline_bg, bold = true },
   St_Lsp = { fg = colors.nord_blue, bg = statusline_bg },
   St_LspMsg = { fg = colors.green, bg = statusline_bg },


### PR DESCRIPTION
…dow visible and fix inactive window statusline

Before:
<img width="998" height="604" alt="image" src="https://github.com/user-attachments/assets/3244b59e-2da8-44b1-9950-7aac0a421da4" />
After:
<img width="956" height="651" alt="image" src="https://github.com/user-attachments/assets/80f907e0-cc3c-4906-8d8a-a254beecf3c7" />
